### PR TITLE
add pypi publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "pcap-parser"
+name = "pcap-extract"
 version = "0.1.0"
 description = "Parse pcap files and extract flow-related information"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,5 @@ pcap-flow = "pcap_parser.flow:main"
 dev = [
     "pytest",
     "ruff",
+    "build",
 ]


### PR DESCRIPTION
### Changes
- added github actions workflow that publishes to pypi on github release using trusted publishers (no api tokens needed)
- added `build` to dev dependencies for local build testing

### Testing
- package builds successfully (`python -m build`)
- workflow triggers only on github releases