### PR TITLE
add pcap-devices command with LLM device identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Python tool to parse pcap files and extract flow-related network traffic informa
 - Hostname enrichment from DNS queries, TLS SNI, DHCP, and reverse DNS
 - Device metadata extraction (OUI vendor, HTTP user-agent)
 - Flow aggregation with packet counts, byte counts, and inter-arrival times
+- Device discovery with per-device traffic summaries
+- LLM-powered device identification via [IoT Inspector](https://github.com/nyu-mlab/iot-inspector-client)
 - Domain extraction from hostnames
 - Persistent IP-to-hostname cache across runs
 
@@ -56,6 +58,26 @@ After parsing, aggregate packets into flows:
 
 ```bash
 pcap-flow output.csv aggregated_flows.csv
+```
+
+### List devices
+
+List all devices found in the capture:
+
+```bash
+pcap-devices output.csv
+```
+
+Identify devices using a fine-tuned LLM:
+
+```bash
+pcap-devices output.csv --identify
+```
+
+Output as JSON:
+
+```bash
+pcap-devices output.csv --json
 ```
 
 ### Output

--- a/pcap_parser/devices.py
+++ b/pcap_parser/devices.py
@@ -19,7 +19,7 @@ import urllib.error
 import pandas as pd
 
 
-DEVID_API_URL = "https://nyu-mlab--dev-id-predict.modal.run"
+DEVID_API_URL = "https://rameen-mahmood--dev-id-predict.modal.run"
 DEVID_API_KEY = "momo"
 
 
@@ -65,14 +65,13 @@ def aggregate_devices(input_csv):
 def identify_device(device):
     """Call the dev-id Modal API to predict device vendor."""
     fields = {
-        "dhcp_hostname": device.get("dhcp_hostname") or "unknown",
-        "remote_hostnames": ", ".join(device.get("top_destinations") or []) or "unknown",
-        "user_agent_info": device.get("user_agent") or "unknown",
-        "oui_friendly": device.get("oui_vendor") or "unknown",
+        "DHCP Hostname": device.get("dhcp_hostname") or "unknown",
+        "Remote Hostnames": ", ".join(device.get("top_destinations") or []) or "unknown",
+        "User Agent": device.get("user_agent") or "unknown",
+        "OUI": device.get("oui_vendor") or "unknown",
     }
 
     payload = json.dumps({
-        "api_key": DEVID_API_KEY,
         "mac_address": device.get("mac", ""),
         "fields": fields,
     }).encode()
@@ -80,7 +79,10 @@ def identify_device(device):
     req = urllib.request.Request(
         DEVID_API_URL,
         data=payload,
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": DEVID_API_KEY,
+        },
     )
 
     try:
@@ -151,7 +153,7 @@ def print_devices(devices, identify=False):
             vendor = identification["vendor"]
             source = identification["source"]
             explanation = identification["explanation"]
-            print(f"  Identified As:  {vendor} (via {source})")
+            print(f"  Identified As:  {vendor.strip()} (via {source})")
             if explanation:
                 if len(explanation) > 100:
                     explanation = explanation[:97] + "..."

--- a/pcap_parser/devices.py
+++ b/pcap_parser/devices.py
@@ -1,0 +1,188 @@
+"""
+List devices found in parsed pcap data.
+
+Groups packets by source MAC address and summarizes each device's metadata
+including IPs, OUI vendor, DHCP hostname, top destinations, and traffic volume.
+
+Usage:
+    pcap-devices parsed_packets.csv
+    pcap-devices parsed_packets.csv --identify
+    pcap-devices parsed_packets.csv --json
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+
+import pandas as pd
+
+
+DEVID_API_URL = "https://nyu-mlab--dev-id-predict.modal.run"
+DEVID_API_KEY = "momo"
+
+
+def aggregate_devices(input_csv):
+    """Group parsed packet CSV by source MAC and return per-device summaries."""
+    df = pd.read_csv(input_csv)
+
+    if "eth.src" not in df.columns:
+        print("[!] No eth.src column found. Is this a pcap-parse output file?")
+        sys.exit(1)
+
+    df = df[df["eth.src"].notna()]
+
+    devices = []
+    for mac, group in df.groupby("eth.src"):
+        ips = group["ip.src"].dropna().unique().tolist()
+        oui = _first_non_empty(group, "eth.src.oui_resolved")
+        dhcp = _first_non_empty(group, "dhcp_hostname")
+        user_agent = _first_non_empty(group, "http.user_agent")
+
+        dst_hosts = group["dst_hostname"].dropna()
+        dst_hosts = dst_hosts[dst_hosts != ""]
+        top_destinations = dst_hosts.value_counts().head(5).index.tolist()
+
+        packet_count = len(group)
+        byte_count = int(group["frame.len"].sum()) if "frame.len" in group.columns else 0
+
+        devices.append({
+            "mac": mac,
+            "ips": ips,
+            "oui_vendor": oui,
+            "dhcp_hostname": dhcp,
+            "user_agent": user_agent,
+            "top_destinations": top_destinations,
+            "packet_count": packet_count,
+            "byte_count": byte_count,
+        })
+
+    devices.sort(key=lambda d: d["byte_count"], reverse=True)
+    return devices
+
+
+def identify_device(device):
+    """Call the dev-id Modal API to predict device vendor."""
+    fields = {
+        "dhcp_hostname": device.get("dhcp_hostname") or "unknown",
+        "remote_hostnames": ", ".join(device.get("top_destinations") or []) or "unknown",
+        "user_agent_info": device.get("user_agent") or "unknown",
+        "oui_friendly": device.get("oui_vendor") or "unknown",
+    }
+
+    payload = json.dumps({
+        "api_key": DEVID_API_KEY,
+        "mac_address": device.get("mac", ""),
+        "fields": fields,
+    }).encode()
+
+    req = urllib.request.Request(
+        DEVID_API_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+            return {
+                "vendor": result.get("vendor", "unknown"),
+                "explanation": result.get("explanation", ""),
+                "source": result.get("source", ""),
+            }
+    except (urllib.error.URLError, json.JSONDecodeError) as e:
+        return {"vendor": "unknown", "explanation": str(e), "source": "error"}
+
+
+def _first_non_empty(group, column):
+    """Return the first non-empty value from a column, or empty string."""
+    if column not in group.columns:
+        return ""
+    vals = group[column].dropna()
+    vals = vals[vals.astype(str).str.strip() != ""]
+    return str(vals.iloc[0]) if len(vals) > 0 else ""
+
+
+def _format_bytes(n):
+    """Format byte count as human-readable string."""
+    for unit in ["B", "KB", "MB", "GB"]:
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} TB"
+
+
+def print_devices(devices, identify=False):
+    """Print device table to stdout."""
+    if not devices:
+        print("[!] No devices found.")
+        return
+
+    if identify:
+        print(f"[+] Identifying {len(devices)} devices via dev-id API...")
+
+    for i, device in enumerate(devices):
+        identification = None
+        if identify:
+            identification = identify_device(device)
+
+        print()
+        print(f"  Device {i + 1}")
+        print(f"  {'=' * 50}")
+        print(f"  MAC:            {device['mac']}")
+        if device["oui_vendor"]:
+            print(f"  OUI Vendor:     {device['oui_vendor']}")
+        if device["dhcp_hostname"]:
+            print(f"  DHCP Hostname:  {device['dhcp_hostname']}")
+        if device["ips"]:
+            print(f"  IPs:            {', '.join(device['ips'][:5])}")
+        if device["user_agent"]:
+            ua = device["user_agent"]
+            if len(ua) > 80:
+                ua = ua[:77] + "..."
+            print(f"  User-Agent:     {ua}")
+        print(f"  Packets:        {device['packet_count']:,}")
+        print(f"  Traffic:        {_format_bytes(device['byte_count'])}")
+        if device["top_destinations"]:
+            print(f"  Top Hosts:      {', '.join(device['top_destinations'][:3])}")
+
+        if identification:
+            vendor = identification["vendor"]
+            source = identification["source"]
+            explanation = identification["explanation"]
+            print(f"  Identified As:  {vendor} (via {source})")
+            if explanation:
+                if len(explanation) > 100:
+                    explanation = explanation[:97] + "..."
+                print(f"  Explanation:    {explanation}")
+
+    print()
+    print(f"  Total: {len(devices)} devices")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="list devices found in parsed pcap data"
+    )
+    parser.add_argument("input", help="path to the parsed csv file (output of pcap-parse)")
+    parser.add_argument("--identify", action="store_true",
+                        help="identify devices using the dev-id LLM API")
+    parser.add_argument("--json", action="store_true", dest="output_json",
+                        help="output as json instead of formatted table")
+    args = parser.parse_args()
+
+    devices = aggregate_devices(args.input)
+
+    if args.output_json:
+        if args.identify:
+            for device in devices:
+                device["identification"] = identify_device(device)
+        print(json.dumps(devices, indent=2))
+    else:
+        print_devices(devices, identify=args.identify)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Issues = "https://github.com/nyu-mlab/pcap-parser/issues"
 [project.scripts]
 pcap-parse = "pcap_parser.parse:main"
 pcap-flow = "pcap_parser.flow:main"
+pcap-devices = "pcap_parser.devices:main"
 
 [project.optional-dependencies]
 dev = [

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,89 @@
+"""Tests for pcap_parser.devices module."""
+
+import pandas as pd
+import pytest
+
+from pcap_parser.devices import aggregate_devices, _first_non_empty, _format_bytes
+
+
+class TestAggregateDevices:
+    @pytest.fixture
+    def parsed_csv(self, tmp_path):
+        """Create a CSV that mimics pcap-parse output with multiple devices."""
+        data = {
+            "frame.time_epoch": [1000.0, 1000.1, 1000.2, 1000.3, 1000.4],
+            "eth.src": ["AA:BB:CC:DD:EE:01"] * 3 + ["AA:BB:CC:DD:EE:02"] * 2,
+            "eth.src.oui_resolved": ["Apple, Inc."] * 3 + ["Google, Inc."] * 2,
+            "ip.src": ["192.168.1.10"] * 3 + ["192.168.1.20"] * 2,
+            "ip.dst": ["93.184.216.34"] * 3 + ["142.250.80.46"] * 2,
+            "frame.len": [100, 200, 300, 150, 250],
+            "dst_hostname": ["example.com"] * 3 + ["google.com"] * 2,
+            "dhcp_hostname": ["macbook", "", "", "pixel-6", ""],
+            "http.user_agent": [None] * 3 + ["Mozilla/5.0 (Linux; Android 12)", None],
+        }
+        df = pd.DataFrame(data)
+        csv_path = str(tmp_path / "parsed.csv")
+        df.to_csv(csv_path, index=False)
+        return csv_path
+
+    def test_finds_correct_device_count(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        assert len(devices) == 2
+
+    def test_sorted_by_traffic_descending(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        assert devices[0]["byte_count"] >= devices[1]["byte_count"]
+
+    def test_device_has_expected_fields(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        device = devices[0]
+        assert "mac" in device
+        assert "ips" in device
+        assert "oui_vendor" in device
+        assert "dhcp_hostname" in device
+        assert "packet_count" in device
+        assert "byte_count" in device
+        assert "top_destinations" in device
+
+    def test_extracts_oui_vendor(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        vendors = {d["oui_vendor"] for d in devices}
+        assert "Apple, Inc." in vendors
+        assert "Google, Inc." in vendors
+
+    def test_extracts_dhcp_hostname(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        hostnames = {d["dhcp_hostname"] for d in devices}
+        assert "macbook" in hostnames
+        assert "pixel-6" in hostnames
+
+    def test_calculates_byte_count(self, parsed_csv):
+        devices = aggregate_devices(parsed_csv)
+        apple_device = next(d for d in devices if d["oui_vendor"] == "Apple, Inc.")
+        assert apple_device["byte_count"] == 600
+        assert apple_device["packet_count"] == 3
+
+
+class TestFormatBytes:
+    def test_bytes(self):
+        assert _format_bytes(500) == "500.0 B"
+
+    def test_kilobytes(self):
+        assert _format_bytes(2048) == "2.0 KB"
+
+    def test_megabytes(self):
+        assert _format_bytes(1048576) == "1.0 MB"
+
+
+class TestFirstNonEmpty:
+    def test_returns_first_value(self):
+        group = pd.DataFrame({"col": ["", "hello", "world"]})
+        assert _first_non_empty(group, "col") == "hello"
+
+    def test_returns_empty_for_missing_column(self):
+        group = pd.DataFrame({"other": [1, 2]})
+        assert _first_non_empty(group, "col") == ""
+
+    def test_returns_empty_for_all_empty(self):
+        group = pd.DataFrame({"col": ["", "", ""]})
+        assert _first_non_empty(group, "col") == ""


### PR DESCRIPTION
### Changes
- added `pcap-devices` command that groups parsed pcap data by source MAC and displays per-device summaries (IPs, OUI vendor, DHCP hostname, user-agent, traffic volume, top destinations)
- added `--identify` flag that calls the device identification API from [IoT Inspector](https://github.com/nyu-mlab/iot-inspector-client) to predict device vendor (see https://github.com/nyu-mlab/iot-inspector-client/wiki/Device-Identification)
- added `--json` flag for machine-readable output
- added 12 tests for device aggregation, formatting helpers, and field extraction

### Testing
- all 39 tests pass
- lint clean