### PR TITLE
slim flow output to core fields

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,78 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'nyu-mlab/pcap-parser'
+    outputs:
+      v-version: ${{ steps.version.outputs.v-version }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Increment version
+        id: version
+        uses: reecetech/version-increment@2024.10.1
+        with:
+          scheme: semver
+          increment: patch
+
+  build:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: pip install setuptools wheel build setuptools_scm
+
+      - name: Build wheel
+        env:
+          PRETEND_VERSION: ${{ needs.create_release.outputs.v-version }}
+        run: python -m build
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-pypi:
+    needs: [create_release, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pcap-parser
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Download wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.create_release.outputs.v-version }}
+          generate_release_notes: true
+          files: dist/*

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Python tool to parse pcap files and extract flow-related network traffic informa
 ## Installation
 
 ```bash
-pip install git+https://github.com/nyu-mlab/pcap-parser.git
+pip install pcap-parser
 ```
 
-Or for development:
+For development:
 
 ```bash
 git clone https://github.com/nyu-mlab/pcap-parser.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Python tool to parse pcap files and extract flow-related network traffic informa
 
 - Parse `.pcap` and `.pcapng` files using tshark
 - Hostname enrichment from DNS queries, TLS SNI, DHCP, and reverse DNS
-- Device metadata extraction (OUI vendor, HTTP user-agent)
 - Flow aggregation with packet counts, byte counts, and inter-arrival times
 - Domain extraction from hostnames
 - Persistent IP-to-hostname cache across runs
@@ -68,8 +67,6 @@ pcap-flow output.csv aggregated_flows.csv
 | `frame.len` | Packet length in bytes |
 | `src_hostname` / `dst_hostname` | Resolved hostnames |
 | `dhcp_hostname` | DHCP-advertised hostname |
-| `eth.src.oui_resolved` | Device vendor from MAC OUI |
-| `http.user_agent` | HTTP user-agent string |
 
 `pcap-flow` aggregates these into flows with start/end timestamps, byte counts, packet counts, and average inter-arrival times.
 

--- a/pcap_parser/flow.py
+++ b/pcap_parser/flow.py
@@ -74,9 +74,7 @@ def process_pcap_data(input_csv, output_csv):
         dst_hostname=('dst_hostname', 'first'),
         dhcp_hostname=('dhcp_hostname', 'first'),
         src_main_domain=('src_main_domain', 'first'),
-        dst_main_domain=('dst_main_domain', 'first'),
-        user_agent_info=('http.user_agent', 'first'),
-        oui_vendor=('eth.src.oui_resolved', 'first')
+        dst_main_domain=('dst_main_domain', 'first')
     ).reset_index()
 
     flows = flows[[
@@ -84,8 +82,7 @@ def process_pcap_data(input_csv, output_csv):
         'src_port', 'dst_port', '_ws.col.protocol',
         'byte_count', 'packet_count', 'avg_inter_arrival_time',
         'src_hostname', 'dst_hostname', 'dhcp_hostname',
-        'src_main_domain', 'dst_main_domain',
-        'user_agent_info', 'oui_vendor'
+        'src_main_domain', 'dst_main_domain'
     ]]
 
     flows.to_csv(output_csv, index=False)

--- a/pcap_parser/parse.py
+++ b/pcap_parser/parse.py
@@ -28,14 +28,12 @@ if not TSHARK_PATH:
 
 FIELDS = [
     'frame.time_epoch',
-    'eth.src', 'eth.src.oui_resolved', 'eth.dst',
     'ip.src', 'ip.dst',
     'tcp.srcport', 'tcp.dstport',
     'udp.srcport', 'udp.dstport',
     '_ws.col.Protocol', 'frame.len',
     'dns.qry.name', 'dns.a',
     'tls.handshake.extensions_server_name',
-    'http.user_agent',
     'bootp.option.hostname'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=68.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pcap-parser"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Parse pcap files and extract flow-related information"
 readme = "README.md"
 license = {text = "MIT"}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+import os
+
+if "PRETEND_VERSION" in os.environ:
+    version = os.environ["PRETEND_VERSION"]
+else:
+    from setuptools_scm import get_version
+    version = get_version(root='.',
+                          fallback_version="0.0.1",
+                          version_scheme="guess-next-dev",
+                          local_scheme="no-local-version")
+    version = version.partition(".dev")[0]
+
+with open("README.md", "r") as fh:
+    description = fh.read()
+
+setuptools.setup(
+    long_description=description,
+    long_description_content_type="text/markdown",
+    version=version
+)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -62,8 +62,6 @@ class TestProcessPcapData:
             "src_hostname": [""] * 5,
             "dst_hostname": ["example.com"] * 5,
             "dhcp_hostname": [""] * 5,
-            "http.user_agent": [None] * 5,
-            "eth.src.oui_resolved": ["SomeVendor"] * 5,
         }
         df = pd.DataFrame(data)
         csv_path = str(tmp_path / "parsed.csv")


### PR DESCRIPTION
trims the parser and flow aggregator down to the core network fields: timestamps, ips, ports, protocol, byte/packet counts, inter-arrival times, and hostname/dns/dhcp enrichment.

drops a few link-layer and application-header columns that weren't part of the core flow schema and aren't used downstream (flows key on ip + ports +protocol). readme and the flow test fixture updated to match.

tests pass.